### PR TITLE
Updates for 0.9.2 Debian release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+rspamd (0.9.2) unstable; urgency=low
+
+  * New release:
+    - Use lua 5.1 if luajit is not available.
+
+ -- Mikhail Gusarov <dottedmag@debian.org>  Tue, 19 May 2015 15:25:54 +0200
+
 rspamd (0.9.1) unstable; urgency=low
 
   * New release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-rspamd (0.9.1) UNRELEASED; urgency=low
+rspamd (0.9.1) unstable; urgency=low
 
   * New release.
 
- -- Mikhail Gusarov <dottedmag@debian.org>  Sun, 17 May 2015 07:38:32 +0200
+ -- Mikhail Gusarov <dottedmag@debian.org>  Sun, 17 May 2015 17:46:32 +0200
 
 rspamd (0.8.3) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rspamd
 Section: mail
 Priority: optional
 Maintainer: Mikhail Gusarov <dottedmag@debian.org>
-Build-Depends: debhelper (>= 9), dpkg-dev (>= 1.16.1~), cmake, libevent-dev (>= 1.3), libglib2.0-dev (>= 2.16.0), libgmime-2.6-dev, libluajit-5.1-dev, libpcre3-dev, libssl-dev (>= 1.0), libcurl4-openssl-dev, libhiredis-dev (>= 0.11.0-4), libsqlite3-dev, perl, dh-systemd
+Build-Depends: debhelper (>= 9), dpkg-dev (>= 1.16.1~), cmake, libevent-dev (>= 1.3), libglib2.0-dev (>= 2.16.0), libgmime-2.6-dev, libluajit-5.1-dev | liblua5.1-dev, libpcre3-dev, libssl-dev (>= 1.0), libcurl4-openssl-dev, libhiredis-dev (>= 0.11.0-4), libsqlite3-dev, perl, dh-systemd
 Standards-Version: 3.9.6
 Homepage: https://rspamd.com
 Vcs-Git: git://github.com/vstakhov/rspamd.git

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rspamd
 Section: mail
 Priority: optional
 Maintainer: Mikhail Gusarov <dottedmag@debian.org>
-Build-Depends: debhelper (>= 9), dpkg-dev (>= 1.16.1~), cmake, libevent-dev (>= 1.3), libglib2.0-dev (>= 2.16.0), libgmime-2.6-dev, libluajit-5.1-dev, libpcre3-dev, libssl-dev (>= 1.0), libcurl4-openssl-dev, libhiredis-dev, libsqlite3-dev, perl, dh-systemd
+Build-Depends: debhelper (>= 9), dpkg-dev (>= 1.16.1~), cmake, libevent-dev (>= 1.3), libglib2.0-dev (>= 2.16.0), libgmime-2.6-dev, libluajit-5.1-dev, libpcre3-dev, libssl-dev (>= 1.0), libcurl4-openssl-dev, libhiredis-dev (>= 0.11.0-4), libsqlite3-dev, perl, dh-systemd
 Standards-Version: 3.9.6
 Homepage: https://rspamd.com
 Vcs-Git: git://github.com/vstakhov/rspamd.git

--- a/debian/rules
+++ b/debian/rules
@@ -3,8 +3,6 @@
 	dh $@ --with systemd
 
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
-# Until https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=739834 is fixed
-export DEB_CFLAGS_MAINT_APPEND = -I/usr/include/hiredis
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DCONFDIR=/etc/rspamd \


### PR DESCRIPTION
- Use lua 5.1 if luajit is not available
- Drop workaround for old libhiredis-dev package
