### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/contrib/exim/local_scan.c
+++ b/contrib/exim/local_scan.c
@@ -331,6 +331,7 @@ int GetAndTransferMessage (int fd, char *sFile)
     char answ [4];
     int	 iStatus;
     int	 Len, ccnt;
+    int	 test;
 
     iStatus = GetFiles ((char *)sFile, fd);
 
@@ -344,10 +345,11 @@ int GetAndTransferMessage (int fd, char *sFile)
     for (ccnt = 0; ccnt <= MAX_FAILS_C; ccnt ++)
     {
 #ifdef RSPAM_UNIXSOCKET
-        if (connect (sock, (struct sockaddr *) &ssun, sizeof (struct sockaddr_un)) < 0)
+        test = connect (sock, (struct sockaddr *) &ssun, sizeof (struct sockaddr_un)) < 0;
 #else
-        if (connect (sock, (struct sockaddr *) &ssin, sizeof (struct sockaddr_in)) < 0)
+        test = connect (sock, (struct sockaddr *) &ssin, sizeof (struct sockaddr_in)) < 0;
 #endif
+        if (test)
         {
             if (ccnt < MAX_FAILS_C)
                 usleep (1000);


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.