### PR TITLE
RBL module: remove `private_ips` setting in favour of `local_addrs`

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -4,8 +4,6 @@ rbl {
     default_received = false;
     default_exclude_users = true;
 
-    private_ips = "127.0.0.0/8 10.0.0.0/8 192.168.0.0/16 169.254.0.0/16 172.16.0.0/12 100.64.0.0/10 fc00::/7 fe80::/10 fec0::/10 ::1";
-
     rbls {
 
         spamhaus {

--- a/doc/markdown/modules/rbl.md
+++ b/doc/markdown/modules/rbl.md
@@ -67,7 +67,7 @@ If set to true, do not use this RBL if the message sender is authenticated.
 
 - default_exclude_private_ips (true)
 
-If true & private_ips is set appropriately, do not use the RBL if the sending host address is in the private IP list & do not check received headers baring these addresses.
+If true, do not use the RBL if the sending host address is in `local_addrs` & do not check received headers baring these addresses.
 
 - default_exclude_local (true)
 
@@ -86,10 +86,6 @@ Other parameters which can be set here are:
 - local_exclude_ip_map
 
 Can be set to a URL of a list of IPv4/IPv6 addresses & subnets not to be considered as local exclusions by exclude_local checks.
-
-- private_ips
-
-Should be set to a space/comma/semicolon-delimited list of addresses & subnets to be considered private by exclude_private_ips checks.
 
 RBL-specific subsection is structured as follows:
 


### PR DESCRIPTION
It's a breaking change only if one decided to edit `private_ips` instead of using `local_exclude_ip_map` as one is supposed to. ;)