### PR TITLE
Skip good hostname check for undefined hostnames

### DIFF
--- a/src/plugins/lua/once_received.lua
+++ b/src/plugins/lua/once_received.lua
@@ -79,13 +79,15 @@ local function check_quantity_received (task)
       return
     end
 
-    local hn = string.lower(r['real_hostname'])
-    -- Check for good hostname
-    if hn and good_hosts then
-      for _,gh in ipairs(good_hosts) do
-        if string.find(hn, gh) then
-          ret = false
-          break
+    if r['real_hostname'] then
+      local hn = string.lower(r['real_hostname'])
+      -- Check for good hostname
+      if hn and good_hosts then
+        for _,gh in ipairs(good_hosts) do
+          if string.find(hn, gh) then
+            ret = false
+            break
+          end
         end
       end
     end


### PR DESCRIPTION
~~~
2016-02-17 13:00:50 #58424(normal) <a41bdc>; task; lua_metric_symbol_callback: call to (ONCE_RECEIVED) failed: /usr/local/share/rspamd/lua/once_received.lua:82: bad argument #1 to 'lower' (string expected, got nil); trace: [1]:{[C]:-1 - lower [C]}; [2]:{/usr/local/share/rspamd/lua/once_received.lua:82 - <unknown> [Lua]};
~~~