### PR TITLE
[Fix] `MIME_BAD_ATTACHMENT` false positives for MDN

### DIFF
--- a/conf/modules.d/mime_types.conf
+++ b/conf/modules.d/mime_types.conf
@@ -22,7 +22,11 @@ mime_types {
     # Match specific extensions to specific content types
     extension_map = {
       html = "text/html";
-      txt = "text/plain";
+      txt = [
+        "message/disposition-notification",
+        "text/plain",
+        "text/rfc822-headers"
+      ];
       pdf = "application/pdf";
     }
 }


### PR DESCRIPTION
I'm not sure if it should be changed  in mime_types.lua ```local settings = {  extension_map = { },}``` as well.
