### PR TITLE
[Minor] Add `application/octet-stream` mime type for `pdf` extension

### DIFF
--- a/conf/modules.d/mime_types.conf
+++ b/conf/modules.d/mime_types.conf
@@ -27,6 +27,9 @@ mime_types {
         "text/plain",
         "text/rfc822-headers"
       ];
-      pdf = "application/pdf";
+      pdf = [
+        "application/octet-stream",
+        "application/pdf"
+      ];
     }
 }


### PR DESCRIPTION
The `application/octet-stream` mime type is commonly used  for `pdf` files by variety of automated mailing systems.