### PR TITLE
[Doc] Accent about `command options` help

### DIFF
--- a/doc/rspamadm.1.md
+++ b/doc/rspamadm.1.md
@@ -8,21 +8,19 @@ rspamadm - rspamd administration utility
 
 rspamadm [*global_options*] [*command*] [*command_options*]...
 
-rspamadm -l
-
-rspamadm help
-
-rspamadm help <command>
-
-rspamadm --help
-
 # DESCRIPTION
 
 `rspamadm` is a routine to manage rspamd spam filtering system. It is intended to perform
 such actions as merging databases, performing configuration tests, encrypting passwords,
-signing configurations and so on. You can get a list of available commands by running
+signing configurations and so on. You can get a list of available **commands** by running
 
     rspamadm -l
+
+Also for each command you can check list of available **command_options** by running
+
+    rspamadm help command
+    rspamadm command --help
+    
 
 # OPTIONS
 

--- a/src/libstat/backends/redis_backend.c
+++ b/src/libstat/backends/redis_backend.c
@@ -767,14 +767,13 @@ rspamd_redis_connected (redisAsyncContext *c, gpointer r, gpointer priv)
 			}
 
 			rt->learned = val;
-
-			rt->conn_state = RSPAMD_REDIS_CONNECTED;
 			REF_RETAIN (rt);
-
 			msg_debug_task ("connected to redis server, tokens learned for %s: %uL",
 					rt->redis_object_expanded, rt->learned);
 			rspamd_upstream_ok (rt->selected);
+			/* This also set state to terminated state */
 			rspamd_session_remove_event (task->s, rspamd_redis_fin, rt);
+			rt->conn_state = RSPAMD_REDIS_CONNECTED;
 		}
 		else {
 			/* This could be caused by removing redis context forcefully */

--- a/src/rspamadm/rspamadm.c
+++ b/src/rspamadm/rspamadm.c
@@ -56,7 +56,7 @@ static GOptionEntry entries[] = {
 			"Redefine UCL variable", NULL},
 	{"help", 'h', 0, G_OPTION_ARG_NONE, &show_help,
 			"Show help", NULL},
-	{"version", 'h', 0, G_OPTION_ARG_NONE, &show_version,
+	{"version", 'v', 0, G_OPTION_ARG_NONE, &show_version,
 			"Show version", NULL},
 	{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
 };


### PR DESCRIPTION
[Minor] Correct rspamadm -v to display actual version intead of help