### PR TITLE
[Conf] Fix fuzzy_check.conf includes order

### DIFF
--- a/conf/modules.d/fuzzy_check.conf
+++ b/conf/modules.d/fuzzy_check.conf
@@ -14,10 +14,6 @@
 # See https://rspamd.com/doc/tutorials/writing_rules.html for details
 
 fuzzy_check {
-    # Include dynamic conf for the rule
-    .include(try=true,priority=5) "${DBDIR}/dynamic/fuzzy_check.conf"
-    .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/fuzzy_check.conf"
-    .include(try=true,priority=10) "$LOCAL_CONFDIR/override.d/fuzzy_check.conf"
     min_bytes = 100;
     rule "rspamd.com" {
         servers = "rspamd.com:11335";
@@ -42,4 +38,8 @@ fuzzy_check {
             }
         }
     }
+    # Include dynamic conf for the rule
+    .include(try=true,priority=5) "${DBDIR}/dynamic/fuzzy_check.conf"
+    .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/fuzzy_check.conf"
+    .include(try=true,priority=10) "$LOCAL_CONFDIR/override.d/fuzzy_check.conf"
 }


### PR DESCRIPTION
This fixes #672 and fixes #563.

1. I am not quite sure if I did this right.
2. I think includes in configuration files for other modules should be relocated the same way.