### PR TITLE
Update acism_create.c

### DIFF
--- a/contrib/aho-corasick/acism_create.c
+++ b/contrib/aho-corasick/acism_create.c
@@ -323,9 +323,15 @@ interleave(TNODE *troot, int nnodes, int nsyms, TNODE **v1, TNODE **v2)
             if (last_trans < last) {
                 last_trans = last;
                 if (last + nsyms >= usev_size) {
-                    usev = realloc(usev, usev_size << 1);
-                    memset(usev + usev_size, 0, usev_size);
-                    usev_size <<= 1;
+                    char *tmp = realloc(usev, usev_size << 1);
+                    if (tmp != NULL) {
+                        usev = tmp;
+                        memset(usev + usev_size, 0, usev_size);
+                        usev_size <<= 1;
+                    } else {
+                        free(usev);
+                        /* And handle error */
+                    }
                 }
             }
         }


### PR DESCRIPTION
W.R.T. https://github.com/mischasan/aho-corasick/pull/17, passing one pointer into realloc() and assigning the result _directly_ into that same pointer variable can cause a memory leak if the reallocation fails, because the original allocation will still exist. The correct way to do this is to use a temporary pointer variable.

Credit: http://stackoverflow.com/a/11548901

Found by https://github.com/bryongloden/cppcheck