### PR TITLE
Update local_scan.c

### DIFF
--- a/contrib/exim/local_scan.c
+++ b/contrib/exim/local_scan.c
@@ -485,7 +485,7 @@ repeat_read:
 int WaitForScanResult (uschar **resStr)
 {
     int Len, i;
-    int rej, result = LOCAL_SCAN_ACCEPT, answer_size, spm = 0, code = 0, ns = 0, smb = 0, urf = 0;
+    int rej = 0, result = LOCAL_SCAN_ACCEPT, answer_size, spm = 0, code = 0, ns = 0, smb = 0, urf = 0;
     char *strP, *tok, *tmp;
     char *hdr = NULL, *hdrv = NULL, *spmStr = NULL, *symbols=NULL, *urls=NULL;
     char answ [4096], state[6], metric[128], back;


### PR DESCRIPTION
`[../rspamd-master/contrib/exim/local_scan.c:630]: (error) Uninitialized variable: rej`

It's always good to initialize integer variables, at least to 0, because if you try to retrieve its value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior.

Found by https://github.com/bryongloden/cppcheck