### PR TITLE
[Minor] Allow for re-enabling default-disabled checks

### DIFF
--- a/src/libserver/cfg_file.h
+++ b/src/libserver/cfg_file.h
@@ -298,6 +298,8 @@ struct rspamd_config {
 	gboolean vectorized_hyperscan;                  /**< use vectorized hyperscan matching					*/
 	gboolean enable_shutdown_workaround;            /**< enable workaround for legacy SA clients (exim)		*/
 	gboolean ignore_received;                       /**< Ignore data from the first received header			*/
+	gboolean check_local;				/** Don't disable any checks for local networks */
+	gboolean check_authed;				/** Don't disable any checks for authenticated users */
 
 	gsize max_diff;                                 /**< maximum diff size for text parts					*/
 	gsize max_cores_size;                           /**< maximum size occupied by rspamd core files			*/

--- a/src/libserver/cfg_rcl.c
+++ b/src/libserver/cfg_rcl.c
@@ -1837,6 +1837,18 @@ rspamd_rcl_config_init (struct rspamd_config *cfg)
 			0,
 			"Emit errors if there are unknown HTTP headers in a request");
 	rspamd_rcl_add_default_handler (sub,
+			"check_local",
+			rspamd_rcl_parse_struct_boolean,
+			G_STRUCT_OFFSET (struct rspamd_config, check_local),
+			0,
+			"Don't disable any checks for local networks");
+	rspamd_rcl_add_default_handler (sub,
+			"check_authed",
+			rspamd_rcl_parse_struct_boolean,
+			G_STRUCT_OFFSET (struct rspamd_config, check_authed),
+			0,
+			"Don't disable any checks for authenticated users");
+	rspamd_rcl_add_default_handler (sub,
 			"check_all_filters",
 			rspamd_rcl_parse_struct_boolean,
 			G_STRUCT_OFFSET (struct rspamd_config, check_all_filters),


### PR DESCRIPTION
`2016-09-29 20:43:52	Stealth	there's no way to prevent rspamd from skipping dkim/spf checks for emails forwarded mby local users?
2016-09-29 20:45:08	Stealth	I have a very special setup, when a portion of email traffic comes from mpop which fetches emails from some pop3 servers and submits them to exim`

So in case mail is injected to Exim by some system user - rspamd treats this as mail from an authenticated user. This is obviously not a recommendable way to use rspamd but I suppose we should support it as best we can.