### PR TITLE
Add rambler redirector

### DIFF
--- a/conf/redirectors.inc
+++ b/conf/redirectors.inc
@@ -578,6 +578,7 @@ lurl.no
 lu2su.net
 lx2.net
 ly9.net
+mail.rambler.ru
 m4u.in
 myooo.info
 miud.in


### PR DESCRIPTION
Rambler Webmail: all links are replaced to https://mail.rambler.ru/m/redirect?url=...