### PR TITLE
[Fix] Deal with multiple ASNs in multimap

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -589,7 +589,9 @@ local function multimap_callback(task, rule)
   elseif rt == 'asn' then
     local asn = task:get_mempool():get_variable('asn')
     if asn then
-      match_rule(rule, asn)
+      each(function(a)
+        match_rule(rule, a)
+      end, rspamd_str_split(asn, ' '))
     end
   elseif rt == 'country' then
     local country = task:get_mempool():get_variable('country')


### PR DESCRIPTION
Will need to do something about `ip_score` too.

Mempool variables misses something like lists; since we have this stuff separated by spaces already that could do for now.