### PR TITLE
[Feature] Some composites to unify SPF/DKIM/DMARC scoring

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -43,6 +43,36 @@ composite "FORGED_MUA_MAILLIST" {
 composite "RBL_SPAMHAUS_XBL_ANY" {
     expression = "RBL_SPAMHAUS_XBL & RECEIVED_SPAMHAUS_XBL";
 }
+composite "AUTH_FAILED1" {
+    expression = "(R_DKIM_REJECT & (R_SPF_FAIL | R_SPF_SOFTFAIL | R_SPF_NEUTRAL) & g:dmarc)";
+    score = 1.0;
+    policy = "remove_weight";
+}
+composite "AUTH_FAILED2" {
+    expression = "(R_DKIM_REJECT & (R_SPF_FAIL | R_SPF_SOFTFAIL | R_SPF_NEUTRAL) & !g:dmarc)";
+    score = 1.0;
+    policy = "remove_weight";
+}
+composite "AUTH_FAILED3" {
+    expression = "((R_SPF_FAIL | R_SPF_SOFTFAIL | R_SPF_NEUTRAL) & !g:dmarc & !g:dkim)";
+    score = 1.0;
+    policy = "remove_weight";
+}
+composite "AUTH_FAILED4" {
+    expression = "(R_DKIM_REJECT & !g:dmarc & !g:spf)";
+    score = 1.0;
+    policy = "remove_weight";
+}
+composite "AUTH_GOOD1" {
+    expression = "(R_DKIM_ALLOW & R_SPF_ALLOW & DMARC_POLICY_ALLOW)";
+    score = -0.5;
+    policy = "remove_weight";
+}
+composite "AUTH_GOOD2" {
+    expression = "(R_DKIM_ALLOW & R_SPF_ALLOW & !g:dmarc)";
+    score = -0.5;
+    policy = "remove_weight";
+}
 composite "AUTH_NA" {
     expression = "R_DKIM_NA & R_SPF_NA & DMARC_NA";
     score = 1.0;


### PR DESCRIPTION
What do you think about this? Idea is to have somewhat consistent scoring for missing/failed/good auth.