### PR TITLE
Added copytruncate arg into logrotate config

### DIFF
--- a/debian/rspamd.logrotate
+++ b/debian/rspamd.logrotate
@@ -4,6 +4,7 @@
        delaycompress
        compress
        notifempty
+       copytruncate
        missingok
        postrotate
           service rspamd reopenlog >/dev/null 2>&1 || true


### PR DESCRIPTION
Hi,

On Ubuntu 16.04 I noticed that after logrotate work rspamd continue write logs to old file which was renamed.
Seems SIGUSR1 (reopenlog call) not work properly and need to fix.

```
$/var/log/rspamd# ls -la
total 32
drwxr-xr-x  2 _rspamd _rspamd 4096 Oct 16 13:41 .
drwxr-xr-x 15 root    syslog  4096 Oct 16 06:25 ..
-rw-r--r--  1 _rspamd _rspamd *5397* Oct 16 13:48 rspamd.log.1
-rw-r--r--  1 _rspamd _rspamd  749 Oct 16 13:41 rspamd.log.2.gz
-rw-r--r--  1 _rspamd _rspamd 3257 Oct 16 13:40 rspamd.log.3.gz
-rw-r--r--  1 _rspamd _rspamd 4274 Oct 16 13:39 rspamd.log.4.gz
root@mxeu1:/var/log/rspamd#  service rspamd reopenlog 
 * Reopen logs for rapid spam filtering system rspamd
   ...done.
$/var/log/rspamd# rspamc < ~test.mail
... some output ..

root@mxeu1:/var/log/rspamd# ls -la
total 32
drwxr-xr-x  2 _rspamd _rspamd 4096 Oct 16 13:41 .
drwxr-xr-x 15 root    syslog  4096 Oct 16 06:25 ..
-rw-r--r--  1 _rspamd _rspamd *6615* Oct 16 13:49 rspamd.log.1
-rw-r--r--  1 _rspamd _rspamd  749 Oct 16 13:41 rspamd.log.2.gz
-rw-r--r--  1 _rspamd _rspamd 3257 Oct 16 13:40 rspamd.log.3.gz
-rw-r--r--  1 _rspamd _rspamd 4274 Oct 16 13:39 rspamd.log.4.gz
```

Actually logrotate provide  _copytruncate_  behavior in which it copy data from original file (ex.rspamd.log) to rotated one so application continuous write to same file. 