### PR TITLE
[Minor] Limit "surbl" group's max score

### DIFF
--- a/conf/metrics.conf
+++ b/conf/metrics.conf
@@ -341,6 +341,8 @@ metric {
     }
 
     group "surbl" {
+        max_score = 9.5;
+
         symbol "SURBL_BLOCKED" {
             weight = 0.0;
             description = "SURBL: blocked by policy/overusage";


### PR DESCRIPTION
@vstakhov , is `one_shot` possible for a group? I think it would be useful in the "surbl"  case.
