### PR TITLE
[Feature] Add subject type to multimap

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -38,6 +38,9 @@ local value_types = {
   header = {
     get_value = function(val) return val end,
   },
+  subject = {
+    get_value = function(val) return val end,
+  },
   rcpt = {
     get_value = function(val) return val end,
   },
@@ -476,6 +479,10 @@ local function multimap_callback(task, rule)
     end
   end
 
+  local function match_subject(r, subject)
+    match_rule(r, subject)
+  end
+
   local function match_addr(r, addr)
     match_list(r, addr, {'addr'})
     match_list(r, addr, {'domain', function(d) return '@' .. d end})
@@ -546,6 +553,11 @@ local function multimap_callback(task, rule)
   elseif rt == 'header' then
     local hv = task:get_header_full(rule['header'])
     match_list(rule, hv, {'decoded'})
+  elseif rt == 'subject' then
+    local subject = task:get_header('subject')
+    if subject then
+        match_subject(rule, subject)
+    end
   elseif rt == 'rcpt' then
     if task:has_recipients('smtp') then
       local rcpts = task:get_recipients('smtp')
@@ -686,6 +698,7 @@ local function add_multimap_rule(key, newrule)
             newrule['map'])
         end
       elseif newrule['type'] == 'header'
+        or newrule['type'] == 'subject'
         or newrule['type'] == 'rcpt'
         or newrule['type'] == 'from'
         or newrule['type'] == 'filename'


### PR DESCRIPTION
Currently the header type of multimap does not return the value decoded if it is base64.
The method task:get_header_full() always makes the value fields and decoded with the subject content in base64, not decoded.

The change provide the possibility of using the subject type in the multimap.conf configuration file, using the method task:get_header('subject') to return the subject decoded.

Multimap configuration example:

```
[root@mail ~]# cat /usr/local/etc/rspamd/local.d/multimap.conf 
BLACKLIST_SUBJECT_REGEX {
        type = "subject";
        regexp = true;
        map = "/usr/local/etc/rspamd/myrules/blacklist-subject.map";
}
```

```
[root@mail ~]# cat /usr/local/etc/rspamd/myrules/blacklist-subject.map
/.*Total\sSales.*/i
```