### PR TITLE
[Minor] Further simplify conditionals

### DIFF
--- a/src/plugins/lua/greylist.lua
+++ b/src/plugins/lua/greylist.lua
@@ -275,11 +275,9 @@ local function greylist_set(task)
   end
 
   local action = task:get_metric_action('default')
-  if action == 'reject' then return end
-  if do_greylisting_required and do_greylisting_required ~= "1" then
+  if action == 'reject' or
+      not do_greylisting_required and action == 'no action' then
     return
-  else
-    if action == 'no action' then return end
   end
   local body_key = data_key(task)
   local meta_key = envelope_key(task)


### PR DESCRIPTION
@AlexeySa I don't understand why strict check`do_greylisting_required ~= "1"` is necessary. More over, I think this [condition](https://github.com/vstakhov/rspamd/blob/4cfb22716f09aa901aaa046fffa5d8c202edf9c1/src/plugins/lua/greylist.lua#L279) will never match. Did I miss something?
So this code
```lua
  if action == 'reject' then return end
  if do_greylisting_required and do_greylisting_required ~= "1" then
    return
  else
    if action == 'no action' then return end
  end
```
could be repaced with
```lua
  if action == 'reject' then return end
  if not do_greylisting_required and action == 'no action' then return end
```
or
```lua
  if action == 'reject' or
      not do_greylisting_required and action == 'no action' then
    return
  end
```