### PR TITLE
[Minor] Reduce priority for greylist/ratelimit modules

### DIFF
--- a/src/plugins/lua/greylist.lua
+++ b/src/plugins/lua/greylist.lua
@@ -378,7 +378,7 @@ if opts then
       name = 'GREYLIST_CHECK',
       type = 'prefilter',
       callback = greylist_check,
-      priority = 10
+      priority = 6
     })
   end
 end

--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -579,7 +579,7 @@ if opts then
         name = 'RATELIMIT_CHECK',
         callback = rate_test,
         type = 'prefilter',
-        priority = 10,
+        priority = 4,
       })
     else
       local symbol


### PR DESCRIPTION
Ratelimit potentially requires information from ASN module.