### PR TITLE
acism: Add missing glib dependency

### DIFF
--- a/contrib/aho-corasick/CMakeLists.txt
+++ b/contrib/aho-corasick/CMakeLists.txt
@@ -6,9 +6,11 @@ endif ()
 
 IF(NOT GPL_RSPAMD_BINARY)
 	ADD_LIBRARY(rspamd-actrie SHARED ${AHOCORASICSRC})
+	target_link_libraries(rspamd-actrie glib-2.0)
 
 	INSTALL(TARGETS rspamd-actrie
 			LIBRARY DESTINATION ${RSPAMD_LIBDIR})
 ELSE()
 	ADD_LIBRARY(rspamd-actrie STATIC ${AHOCORASICSRC})
+	target_link_libraries(rspamd-actrie glib-2.0)
 ENDIF()

--- a/contrib/aho-corasick/acism.c
+++ b/contrib/aho-corasick/acism.c
@@ -17,6 +17,8 @@
 ** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+#include <glib.h>
+
 #include "_acism.h"
 #include "unix-std.h"
 


### PR DESCRIPTION
This library uses g_ascii_tolower()