### PR TITLE
[WebUI] fix savesymbols absolute url to relative

### DIFF
--- a/interface/js/rspamd.js
+++ b/interface/js/rspamd.js
@@ -768,7 +768,7 @@
                     });
                     symbols.columns.adjust().draw();
                     $('#symbolsTable :button').on('click',
-                        function(){saveSymbols("/savesymbols", "symbolsTable")});
+                        function(){saveSymbols("./savesymbols", "symbolsTable")});
                 },
                 error: function (data) {
                     alertMessage('alert-modal alert-error', data.statusText);


### PR DESCRIPTION
With nginx proxy you can't use absolute /savesymbols due to rspamd being proxies as /rspamd/