### PR TITLE
Fix shm on DragonFly

### DIFF
--- a/src/libutil/http.c
+++ b/src/libutil/http.c
@@ -2371,7 +2371,13 @@ rspamd_http_message_set_body (struct rspamd_http_message *msg,
 		storage->shared.name = g_slice_alloc (sizeof (*storage->shared.name));
 		REF_INIT_RETAIN (storage->shared.name, rspamd_http_shname_dtor);
 #ifdef HAVE_SANE_SHMEM
+#if defined(__DragonFly__)
+		// DragonFly uses regular files for shm. User rspamd is not allowed to create
+		// files in the root.
+		storage->shared.name->shm_name = g_strdup ("/tmp/rhm.XXXXXXXXXXXXXXXXXXXX");
+#else
 		storage->shared.name->shm_name = g_strdup ("/rhm.XXXXXXXXXXXXXXXXXXXX");
+#endif
 		storage->shared.shm_fd = rspamd_shmem_mkstemp (storage->shared.name->shm_name);
 #else
 		/* XXX: assume that tempdir is /tmp */


### PR DESCRIPTION
Rspamd tried to call shm_open(3) with a path in the root filesystem
(e.g. /rhm.3f0fd440d46fac91e1b4). But DragonFly uses regular files
for shm. Obviously, this fails, because rspamd has no permissions
to create files in the root (/).

Lots of lines like the following were found in
/var/log/rspamd/rspamd.log before this patch:

    rspamd_shmem_mkstemp: /usr/obj/dports/mail/rspamd/rspamd-1.4.1/src
      /libutil/util.c:1970: failed to create temp shmem
      /rhm.3f0fd440d46fac91e1b4: Permission denied

Also, rspamd made the receiving of mail very slow, when used
in the pre-accept rmilter setting, due to these errors. Even
worse, it just didn't filter emails at all.

This patch fixes the problem by creating the shm files in /tmp
for DragonFly. With this patch applied, these lines are gone from
the log and emails now correctly contain the X-Spamd-Result header,
AND receiving mails is now much much faster.

For rspamd 1.4.1, we will fix it in dports: https://github.com/DragonFlyBSD/DeltaPorts/pull/727