### PR TITLE
Multimap: don't try handle gaps in Received headers

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -712,14 +712,8 @@ local function multimap_callback(task, rule)
     received = function()
       local hdrs = task:get_received_headers()
       if hdrs and hdrs[1] then
-        local num_hdrs = 0
-        for i in ipairs(hdrs) do
-          if i > num_hdrs then
-            num_hdrs = i
-          end
-        end
         for pos, h in ipairs(hdrs) do
-          match_received_header(rule, pos, num_hdrs, h)
+          match_received_header(rule, pos, #hdrs, h)
         end
       end
     end,


### PR DESCRIPTION
I am not sure, why did I think there might be gaps here- I'm not able to reproduce that.

It might be useful to have empty entries in place of headers that couldn't be parsed for positioning purposes.