### PR TITLE
[Minor] Use fake User-Agent in URL redirector plugin

### DIFF
--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -89,6 +89,9 @@ local function resolve_cached(task, orig_url, url, key, param, ntries)
     end
 
     rspamd_http.request{
+      headers = {
+        ['User-Agent'] = 'Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 Fennec/10.0.1',
+      },
       url = url,
       task = task,
       method = 'head',


### PR DESCRIPTION
`fb.me` wants to see a user-agent to serve a redirect to the correct location. OTOH, it seems redirected URLs will always be under .facebook.com so it is not particularly useful to check it.