### PR TITLE
Rules updates

### DIFF
--- a/rules/headers_checks.lua
+++ b/rules/headers_checks.lua
@@ -881,3 +881,23 @@ rspamd_config:register_symbol{
   type = 'virtual',
   description = 'Some of the recipients match the envelope',
 }
+
+rspamd_config.CTYPE_MISSING_DISPOSITION = {
+  callback = function(task)
+    local parts = task:get_parts()
+    if (not parts) or (parts and #parts < 1) then return false end
+    for _,p in ipairs(parts) do
+      local ct = p:get_header('Content-Type')
+      if (ct and ct:lower():match('^application/octet%-stream') ~= nil) then
+        local cd = p:get_header('Content-Disposition')
+        if (not cd) or (cd and cd:lower():find('^attachment') == nil) then
+          return true
+        end
+      end
+    end
+    return false
+  end,
+  description = 'Binary content-type not specified as an attachment',
+  score = 4.0,
+  group = 'header'
+}

--- a/rules/misc.lua
+++ b/rules/misc.lua
@@ -204,6 +204,8 @@ local check_rcvd = rspamd_config:register_symbol{
       local rcvd = rcvds[1]
       if rcvd.flags and rcvd.flags['ssl'] then
         task:insert_result('RCVD_TLS_LAST', 1.0)
+      else
+        task:insert_result('RCVD_NO_TLS_LAST', 1.0)
       end
     end
 
@@ -231,6 +233,15 @@ rspamd_config:register_symbol{
   parent = check_rcvd,
   name = 'RCVD_TLS_LAST',
   description = 'Last hop used encrypted transports',
+  score = 0.0,
+  group = 'encryption'
+}
+
+rspamd_config:register_symbol{
+  type = 'virtual',
+  parent = check_rcvd,
+  name = 'RCVD_NO_TLS_LAST',
+  description = 'Last hop did not use encrypted transports',
   score = 0.0,
   group = 'encryption'
 }

--- a/rules/regexp/misc.lua
+++ b/rules/regexp/misc.lua
@@ -19,7 +19,7 @@ local reconf = config['regexp']
 
 reconf['HTML_META_REFRESH_URL'] = {
   -- Requires options { check_attachements = true; }
-  re = '/<meta\\s+http-equiv="refresh"\\s+content="\\d+;url=/{sa_raw_body}i',
+  re = '/<meta\\s+http-equiv="refresh"\\s+content="\\d+\\s*;\\s*url=/{sa_raw_body}i',
   description = "Has HTML Meta refresh URL",
   score = 5.0,
   group = 'HTML'


### PR DESCRIPTION
- Add RCVD_NO_TLS_LAST symbol, for scoring all messages delivered without TLS (disabled by default, requested by last1 on IRC).

- Fix HTML_META_HTTP_REFRESH to match then spaces/tabs are used (reported by last1)

- Add CTYPE_MISSING_DISPOSITION