### PR TITLE
Handle for ACC and OK messages from sophos

### DIFF
--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -484,7 +484,7 @@ local function sophos_check(task, rule)
               rspamd_logger.infox(task, '%s [%s]: message is clean', rule['symbol'], rule['type'])
             end
             save_av_cache(task, rule, 'OK')
-          elseif string.find(data, 'ACC') then
+          elseif string.find(data, 'ACC') or string.find(data, 'OK SSSP') then
             conn:add_read(sophos_callback)
           else
             rspamd_logger.errx(task, 'unhandled response: %s', data)

--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -450,7 +450,7 @@ local function sophos_check(task, rule)
     local streamsize = string.format('SCANDATA %d\n', task:get_size())
     local bye = 'BYE\n'
 
-    local function sophos_callback(err, data)
+    local function sophos_callback(err, data, conn)
       if err then
         if err == 'IO timeout' then
           if retransmits > 0 then
@@ -484,6 +484,8 @@ local function sophos_check(task, rule)
               rspamd_logger.infox(task, '%s [%s]: message is clean', rule['symbol'], rule['type'])
             end
             save_av_cache(task, rule, 'OK')
+          elseif string.find(data, 'ACC') then
+            conn:add_read(sophos_callback)
           else
             rspamd_logger.errx(task, 'unhandled response: %s', data)
           end


### PR DESCRIPTION
The savdid daemon, tested under Debian jessie, acknowledges commands with 'ACC xyz' and the protocol version with 'OK SSSPx/y'. This patch makes a new read callback if such a message arrives.