### PR TITLE
[Conf] Remove ratelimits from default configuration

### DIFF
--- a/conf/modules.d/ratelimit.conf
+++ b/conf/modules.d/ratelimit.conf
@@ -14,20 +14,20 @@
 # See https://rspamd.com/doc/tutorials/writing_rules.html for details
 
 ratelimit {
-    rates {
-        # Limit for all mail per recipient (burst 100, rate 2 per minute)
-        to = [100, 0.033333333];
-        # Limit for all mail per one source ip (burst 30, rate 1.5 per minute)
-        to_ip = [30, 0.025];
-        # Limit for all mail per one source ip and from address (burst 20, rate 1 per minute)
-        to_ip_from = [20, 0.01666666667];
-        # Limit for all bounce mail (burst 10, rate 2 per hour)
-        bounce_to = [10, 0.000555556];
-        # Limit for bounce mail per one source ip (burst 5, rate 1 per hour)
-        bounce_to_ip = [5, 0.000277778];
-        # Limit for all mail per authenticated user (burst 20, rate 1 per minute)
-        user = [20, 0.01666666667];
-    }
+    #rates {
+        # Limit for all mail per recipient (rate 2 per minute)
+        #to = "2 / 1m";
+        # Limit for all mail per one source ip (rate 1.5 per minute)
+        #to_ip = "3 / 2m";
+        # Limit for all mail per one source ip and from address (rate 1 per minute)
+        #to_ip_from = "1 / 1m";
+        # Limit for all bounce mail (rate 2 per hour)
+        #bounce_to = "2 / 1h";
+        # Limit for bounce mail per one source ip (rate 1 per hour)
+        #bounce_to_ip = "1 / 1h";
+        # Limit for all mail per authenticated user (rate 1 per minute)
+        #user = "1 / 1m";
+    #}
     # If symbol is specified, then it is inserted instead of setting result
     #symbol = "R_RATELIMIT";
     whitelisted_rcpts = "postmaster,mailer-daemon";


### PR DESCRIPTION
I don't think these should feature in default configuration as we can't very well suggest reasonable values for them and they're likely to take users by surprise.