### PR TITLE
[Minor] Fix R_MISSING_CHARSET rule

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -93,7 +93,7 @@ reconf['R_RCVD_SPAMBOTS'] = {
 
 -- Charset is missing in message
 reconf['R_MISSING_CHARSET'] = {
-  re = string.format('content_type_is_type(text) & !content_type_has_param(charset) & !%s',
+  re = string.format('!is_empty_body() & content_type_is_type(text) & !content_type_has_param(charset) & !%s',
     'compare_transfer_encoding(7bit)'),
   score = 2.5,
   description = 'Charset is missing in a message',


### PR DESCRIPTION
Do not trigger on messages with empty payload body as Content-Type header is not mandatory (RFC7231).