### PR TITLE
[Minor] Do not punish OpenPGP/MIME attachments

### DIFF
--- a/rules/headers_checks.lua
+++ b/rules/headers_checks.lua
@@ -897,7 +897,10 @@ rspamd_config.CTYPE_MISSING_DISPOSITION = {
         local cd = p:get_header('Content-Disposition')
         if (not cd) or (cd and cd:lower():find('^attachment') == nil) then
           local ci = p:get_header('Content-ID')
-          if ci then return false end
+          if ci or (#parts > 1 and (cd and cd:find('filename=.+%.asc') ~= nil))
+          then
+            return false
+          end
           return true
         end
       end


### PR DESCRIPTION
Fixes #1655 by checking if there are at least 2 MIME parts (required by the RFC) and checking if the attachment has the .asc file extension.