### PR TITLE
Fix lua_util_is_utf_spoofed logic

### DIFF
--- a/src/lua/lua_util.c
+++ b/src/lua/lua_util.c
@@ -1973,8 +1973,8 @@ lua_util_is_utf_spoofed (lua_State *L)
 			uspoof_setChecks (spc_sgl,
 					USPOOF_ALL_CHECKS & ~USPOOF_WHOLE_SCRIPT_CONFUSABLE,
 					&uc_err);
-			uspoof_setAllowedChars (spc_sgl, allowed, &uc_err);
 #if U_ICU_VERSION_MAJOR_NUM >= 51
+			uspoof_setAllowedChars (spc_sgl, allowed, &uc_err);
 			uspoof_setRestrictionLevel (spc_sgl, USPOOF_MODERATELY_RESTRICTIVE);
 #endif
 		}


### PR DESCRIPTION
When compiled against libicu < 51 the list of allowed characters was
set to none, so all strings were flagged as spoofed.

Fixes #1689.

I didn't do exhaustive testing, but with this patch OMOGRAPH_URL doesn't flag 'google.com' and does flag 'googlе.com', while the unpatched version flags both.