### PR TITLE
IP netmask support for Redis multimap

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -383,11 +383,13 @@ local function multimap_callback(task, rule)
         (r['filter'] == 'real_ip' or r['filter'] == 'from_ip' or not r['filter'])) then
         srch = {value:to_string()}
         cmd = 'HMGET'
-        local bits = 128
+        local maxbits = 128
+        local minbits = 32
         if value:get_version() == 4 then
-            bits = 32
+            maxbits = 32
+            minbits = 8
         end
-        for i=bits,1,-1 do
+        for i=maxbits,minbits,-1 do
             local nip = value:apply_mask(i):to_string() .. "/" .. i
             table.insert(srch, nip)
         end


### PR DESCRIPTION
[Multimap](https://rspamd.com/doc/modules/multimap.html)s of type `ip` currently only support IP addresses (e.g. 192.0.2.1) and not IP networks in CIDR notation (e.g. 192.0.2.0/24). Other places, like [user settings](https://www.rspamd.com/doc/configuration/settings.html), do support networks.

For consistency and to make it possible to specify a range of hosts without needing to create dozens of individual entries, this pull request adds support for networks to the multimap module. As one cannot search Redis for keys by matching a CIDR specification, this means we need to loop over all possible network masks.

Originally reported in https://github.com/mailcow/mailcow-dockerized/issues/412.