### PR TITLE
[Fix] Don't use whitelist/greylist maps as regexp, but as map

### DIFF
--- a/src/plugins/lua/greylist.lua
+++ b/src/plugins/lua/greylist.lua
@@ -413,7 +413,7 @@ if opts then
   whitelisted_ip = rspamd_map_add('greylist', 'whitelisted_ip', 'radix',
     'Greylist whitelist ip map')
   whitelist_domains_map = rspamd_map_add('greylist', 'whitelist_domains_url',
-    'regexp', 'Greylist whitelist domains map')
+    'map', 'Greylist whitelist domains map')
 
   redis_params = rspamd_parse_redis_server('greylist')
   if not redis_params then

--- a/src/plugins/lua/whitelist.lua
+++ b/src/plugins/lua/whitelist.lua
@@ -208,7 +208,7 @@ local configure_whitelist_module = function()
           rule['map'] = rspamd_config:add_map{
             url = rule['domains'],
             description = "Whitelist map for " .. symbol,
-            type = 'regexp'
+            type = 'map'
           }
         elseif type(rule['domains']) == 'table' then
           -- Transform ['domain1', 'domain2' ...] to indexes:
@@ -236,7 +236,7 @@ local configure_whitelist_module = function()
             rule['map'] = rspamd_config:add_map{
               url = rule['domains'],
               description = "Whitelist map for " .. symbol,
-              type = 'regexp'
+              type = 'map'
             }
           end
         else


### PR DESCRIPTION
In whitelist & greylist module, the domain files (like spf_dkim_whitelist.inc, etc) were read as regexp map.
This caused the following false whitelists:
WHITELIST_SPF_DKIM(-3)[onmicrosoft.com]
this while only 'microsoft.com' was in the list!

Reading the maps as 'map'/'hash' instead of 'regexp' fixes the issue.