### PR TITLE
Backport "IP netmask support for Redis multimap" to 1.6

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -383,11 +383,13 @@ local function multimap_callback(task, rule)
         (r['filter'] == 'real_ip' or r['filter'] == 'from_ip' or not r['filter'])) then
         srch = {value:to_string()}
         cmd = 'HMGET'
-        local bits = 128
+        local maxbits = 128
+        local minbits = 32
         if value:get_version() == 4 then
-            bits = 32
+            maxbits = 32
+            minbits = 8
         end
-        for i=bits,1,-1 do
+        for i=maxbits,minbits,-1 do
             local nip = value:apply_mask(i):to_string() .. "/" .. i
             table.insert(srch, nip)
         end


### PR DESCRIPTION
This is a cherry-pick of #1753 to the stable 1.6 version so that the fix can be included in an upcoming 1.6.3 release.

The original pull request fixed inconsistent behavior of multimaps of type `ip`: they did not support netmasks when they were stored in Redis.