### PR TITLE
[Fix] Lua: lpeg to be loaded with rspamd_lua_add_preload

### DIFF
--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -334,7 +334,6 @@ rspamd_lua_init ()
 	luaopen_fann (L);
 	luaopen_sqlite3 (L);
 	luaopen_cryptobox (L);
-	luaopen_lpeg (L);
 
 	luaL_newmetatable (L, "rspamd{ev_base}");
 	lua_pushstring (L, "class");
@@ -349,6 +348,7 @@ rspamd_lua_init ()
 	lua_pop (L, 1);
 
 	rspamd_lua_new_class (L, "rspamd{worker}", worker_reg);
+	rspamd_lua_add_preload (L, "lpeg", luaopen_lpeg);
 	rspamd_lua_add_preload (L, "ucl", luaopen_ucl);
 
 	/* Add plugins global */


### PR DESCRIPTION
My compiled rspamd-1.6.2 crashes on launch, unable to expose its (embedded) lpeg to the config scripts.

2017-07-20 02:24:42 #35995(main) <5fw8hp>; cfg; rspamd_config_read: rcl parse error: cannot init lua file /usr/local/rspamd-1.6.2/share/rspamd/rules/rspamd.lua: /usr/local/rspamd-1.6.2/share/rspamd/lib/lua_util.lua:2: module 'lpeg' not found:
        no field package.preload['lpeg']
        no file '/usr/local/rspamd-1.6.2/share/rspamd/lua/lpeg.lua'
        no file '/usr/local/rspamd-1.6.2/etc/rspamd/lua/lpeg.lua'
        no file '/usr/local/rspamd-1.6.2/share/rspamd/rules/lpeg.lua'
        no file '/usr/local/rspamd-1.6.2/share/rspamd/lib/lpeg.lua'
        no file '/usr/local/rspamd-1.6.2/share/rspamd/lib/lpeg.so'
        no file '/usr/local/share/lua/5.3/lpeg.lua'
        no file '/usr/local/share/lua/5.3/lpeg/init.lua'
        no file '/usr/local/lib/lua/5.3/lpeg.lua'
        no file '/usr/local/lib/lua/5.3/lpeg/init.lua'
        no file './lpeg.lua'
        no file './lpeg/init.lua'
        no file '/usr/local/lib/lua/5.3/lpeg.so'
        no file '/usr/local/lib/lua/5.3/loadall.so'
        no file './lpeg.so'; trace: [1]:{[C]:-1 - require [C]}; [2]:{/usr/local/rspamd-1.6.2/share/rspamd/lib/lua_util.lua:2 - <unknown> [main]}; [3]:{[C]:-1 - require [C]}; [4]:{...local/rspamd-1.6.2/share/rspamd/lib/global_functions.lua:2 - <unknown> [main]}; [5]:{[C]:-1 - require [C]}; [6]:{rspamd.lua:19 - <unknown> [main]};