### PR TITLE
[Fix] Crash in URL processing

### DIFF
--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -2546,7 +2546,7 @@ rspamd_url_task_subject_callback (struct rspamd_url *url, gsize start_offset,
 						" %*s", url_str, url->querylen, url->query);
 
 				if ((existing = g_hash_table_lookup (task->urls,
-						query_url))) {
+						query_url)) == NULL) {
 					g_hash_table_insert (task->urls,
 							query_url,
 							query_url);


### PR DESCRIPTION
```
Program terminated with signal 11, Segmentation fault.
#0  rspamd_url_task_subject_callback (url=0x7fe5c6308408, start_offset=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/url.c:2555
2555						existing->count ++;
Missing separate debuginfos, use: debuginfo-install file-libs-5.14-15.4.x86_64 glibc-2.12-1.209.el6_9.2.x86_64 keyutils-libs-1.4-5.el6.x86_64 krb5-libs-1.10.3-65.el6.x86_64 libcom_err-1.41.12-23.el6.x86_64 libevent-1.4.13-4.el6.x86_64 libgcc-4.4.7-18.el6.x86_64 libicu-4.2.1-14.el6.x86_64 libselinux-2.0.94-7.el6.x86_64 libstdc++-4.4.7-18.el6.x86_64 openssl-1.0.1e-57.el6.x86_64 sqlite-3.6.20-1.el6_7.2.x86_64 zlib-1.2.3-29.el6.x86_64
(gdb) p existing
$1 = (struct rspamd_url *) 0x0
(gdb) bt
#0  rspamd_url_task_subject_callback (url=0x7fe5c6308408, start_offset=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/url.c:2555
#1  0x00000000004ee24a in rspamd_url_trie_generic_callback_common (strnum=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/url.c:2298
#2  0x00000000005305a2 in rspamd_multipattern_hs_cb (id=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libutil/multipattern.c:624
#3  0x000000000077fabf in corei7_roseFloatingCallback ()
#4  0x00000000009ac707 in fdr_engine_exec ()
#5  0x00000000009afe1c in corei7_fdrExec ()
#6  0x0000000000753c59 in corei7_roseBlockExec ()
#7  0x000000000072b406 in corei7_hs_scan ()
#8  0x00000000005312a5 in rspamd_multipattern_lookup (mp=0x7fe5c9fec480, in=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libutil/multipattern.c:688
#9  0x00000000004ece05 in rspamd_url_find_multiple (pool=0x7fe5c98e8680, in=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/url.c:2466
#10 0x00000000005033dc in rspamd_message_parse (task=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libmime/message.c:1096
#11 0x00000000004e8f24 in rspamd_task_process (task=0x7fe5c7e22f00, stages=16383) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/task.c:709
#12 0x00000000004e8e7f in rspamd_task_process (task=0x7fe5c7e22f00, stages=16383) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/task.c:818
#13 0x00000000004e8e7f in rspamd_task_process (task=0x7fe5c7e22f00, stages=16383) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/task.c:818
#14 0x000000000045b78d in rspamd_worker_body_handler (conn=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/worker.c:273
#15 0x00000000004815c7 in rspamd_http_on_message_complete (parser=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libutil/http.c:947
#16 0x0000000000cf6cea in http_parser_execute (parser=0x7fe5c9efd630, settings=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/contrib/http-parser/http_parser.c:1772
#17 0x000000000048310c in rspamd_http_event_handler (fd=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libutil/http.c:1177
#18 0x00007fe5d5221b44 in event_base_loop () from /usr/lib64/libevent-1.4.so.2
#19 0x000000000045be9d in start_worker (worker=0x7fe5c818c700) at /usr/src/debug/rspamd-1.6.2.7/src/worker.c:690
#20 0x00000000004ef9b9 in rspamd_fork_worker (rspamd_main=0x7fe5d0233000, cf=0x7fe5d039f880, index=23, ev_base=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/libserver/worker_util.c:606
#21 0x0000000000459ed3 in spawn_worker_type (rspamd_main=0x7fe5d0233000, ev_base=0x7fe5d02b3c00, cf=0x7fe5d039f880) at /usr/src/debug/rspamd-1.6.2.7/src/rspamd.c:523
#22 0x000000000045a4a1 in spawn_workers (rspamd_main=0x7fe5d0233000, ev_base=0x7fe5d02b3c00) at /usr/src/debug/rspamd-1.6.2.7/src/rspamd.c:615
#23 0x00007fe5d5221b44 in event_base_loop () from /usr/lib64/libevent-1.4.so.2
#24 0x000000000044cf0b in main (argc=<value optimized out>, argv=<value optimized out>, env=Unhandled dwarf expression opcode 0xf3
) at /usr/src/debug/rspamd-1.6.2.7/src/rspamd.c:1400
```