### PR TITLE
MX_MISSING is RFC-compliant and should not increment score

### DIFF
--- a/src/plugins/lua/mx_check.lua
+++ b/src/plugins/lua/mx_check.lua
@@ -186,7 +186,7 @@ local function mx_check(task)
         task = task,
         forced = true
       })
-      task:insert_result(settings.symbol_no_mx, 1.0, err)
+      task:insert_result(settings.symbol_no_mx, 0.0, err)
     else
       table.sort(results, function(r1, r2)
         return r1['priority'] < r2['priority']


### PR DESCRIPTION
When a domain has no MX record, an implicit MX record pointing to the domain name is assumed and the symbol _MX_MISSING_ is added. This comes with a score of 1.0. However, such implicit MX records are perfectly standards-compliant and found with surprisingly many legitimate mail servers. For details on implicit MX records, see [RFC 5321](https://tools.ietf.org/html/rfc5321) section 5 or [Wikipedia](https://en.wikipedia.org/wiki/MX_record#History_of_fallback_to_address_record).

This pull request sets the score of the symbol to zero so that this RFC-compliant and somewhat widespread behavior is not punished.