### PR TITLE
[Fix] Use weight from map for fuzzy scoring

### DIFF
--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -1775,6 +1775,7 @@ fuzzy_insert_result (struct fuzzy_client_session *session,
 	const gchar *symbol;
 	struct fuzzy_mapping *map;
 	struct rspamd_task *task = session->task;
+	double weight;
 	double nval;
 	guchar buf[2048];
 	const gchar *type = "bin";
@@ -1785,11 +1786,12 @@ fuzzy_insert_result (struct fuzzy_client_session *session,
 					GINT_TO_POINTER (rep->flag))) == NULL) {
 		/* Default symbol and default weight */
 		symbol = session->rule->symbol;
-
+		weight = session->rule->max_score;
 	}
 	else {
 		/* Get symbol and weight from map */
 		symbol = map->symbol;
+		weight = map->weight;
 	}
 
 
@@ -1799,8 +1801,7 @@ fuzzy_insert_result (struct fuzzy_client_session *session,
 	 * Otherwise `value` means error code
 	 */
 
-	nval = fuzzy_normalize (rep->value,
-			session->rule->max_score);
+	nval = fuzzy_normalize (rep->value, weight);
 
 	if (io && (io->flags & FUZZY_CMD_FLAG_IMAGE)) {
 		nval *= rspamd_normalize_probability (rep->prob, 0.5);


### PR DESCRIPTION
Currently if you have for example the following config:
`        local {
            servers = "localhost:11335";
            symbol = "LOCAL_FUZZY_UNKNOWN";
            mime_types [
                "application/*",
            ]
            max_score = 20.0;
            read_only = false;
            skip_unknown = true;
            algorithm = "mumhash";
            fuzzy_map {
                LOCAL_FUZZY_DENIED {
                    max_score = 20.0;
                    flag = 11;
                }
                LOCAL_FUZZY_PROB {
                    max_score = 10.0;
                    flag = 12;
                }
                LOCAL_FUZZY_WHITE {
                    max_score = 2.0;
                    flag = 13;
                }
            }
        }
`

Then rspamd will use the global max_score (which is 20). For calculation of the score.
This while it should use the defined max_score in the fuzzy_map entries.