### PR TITLE
User settings: add header rules

### DIFF
--- a/src/plugins/lua/settings.lua
+++ b/src/plugins/lua/settings.lua
@@ -250,6 +250,19 @@ local function check_settings(task)
       end
     end
 
+    if rule['header'] then
+      for k, v in pairs(rule['header']) do
+        local h = task:get_header(k)
+        res = (h and v:match(h))
+        if res then
+          break
+        end
+      end
+      if not res then
+        return nil
+      end
+    end
+
     if res then
       if rule['whitelist'] then
         rule['apply'] = {whitelist = true}
@@ -482,6 +495,19 @@ local function process_settings_table(tbl)
         end
       end
       out['request_header'] = rho
+    end
+    if elt['header'] then
+      local rho = {}
+      for k, v in pairs(elt['header']) do
+        local re = rspamd_regexp.get_cached(v)
+        if not re then
+          re = rspamd_regexp.create_cached(v)
+        end
+        if re then
+          rho[k] = re
+        end
+      end
+      out['header'] = rho
     end
 
     -- Now we must process actions


### PR DESCRIPTION
This adds a `header` rule type to the [user settings](https://www.rspamd.com/doc/configuration/settings.html) to match MIME headers of the message being checked. It works analogous to the `request_header` rule type, which matches rspamd's internal request headers. So for example, to match all messages that have a subject containing a certain word, you would use
```
settings {
	some_subject {
		id = "some_subject";
		header = {
			"Subject" = "/something/i";
		}
		apply "default" {
			something_found = 10.0;
		}
		symbols [
			"something_found"
		]
	}
}
```
Of course, this can be used for any header present in an incoming message.