### PR TITLE
lua auth_results: authres header needs property for "policy". Make it as a comment for dmarc. Fixes some parsers.

### DIFF
--- a/lualib/auth_results.lua
+++ b/lualib/auth_results.lua
@@ -116,7 +116,7 @@ local function gen_auth_results(task, settings)
           hdr = hdr .. key
         end
         if key == 'pass' then
-          hdr = hdr .. ' policy=' .. opts[2]
+          hdr = hdr .. ' (policy=' .. opts[2] .. ')'
           hdr = hdr .. ' header.from=' .. opts[1]
         elseif key ~= 'none' then
           local t = global.rspamd_str_split(opts[1], ' : ')
@@ -127,9 +127,9 @@ local function gen_auth_results(task, settings)
           end
           hdr = hdr .. ' header.from=' .. dom
           if key == 'softfail' then
-            hdr = hdr .. ' policy=none'
+            hdr = hdr .. ' (policy=none)'
           else
-            hdr = hdr .. ' policy=' .. key
+            hdr = hdr .. ' (policy=' .. key .. ')'
           end
         end
         table.insert(hdr_parts, hdr)


### PR DESCRIPTION
RFC5451 stands that policy is reserved ptype and needs to have property. Without this some parsers starting to crash or omit completely authres header. 
To avoid confusion and still leave it for informational purposes we can move it simply as a "comment".
