### PR TITLE
Fix display of symbols at least in chrome

### DIFF
--- a/interface/js/app/history.js
+++ b/interface/js/app/history.js
@@ -117,7 +117,7 @@ function($, _, Humanize) {
             preprocess_item(item);
             Object.keys(item.symbols).map(function(key) {
                 var sym = item.symbols[key];
-                if (!sym.name) {
+                if (!sym.name || sym.name == "undefined") {
                     sym.name = key;
                 }
                 var str = '<strong>' + sym.name + '</strong>' + "(" + sym.score + ")";


### PR DESCRIPTION
In chrome at least sym.name value is defined to "undefined" string and thus all symbol get displayed as undefined