### PR TITLE
Fix undefined symbol name in webui.

### DIFF
--- a/interface/js/app/history.js
+++ b/interface/js/app/history.js
@@ -63,7 +63,9 @@ function($, _, Humanize) {
                 case "symbols":
                     Object.keys(item.symbols).map(function(key) {
                         var sym = item.symbols[key];
-
+                        if (!sym.name) {
+                            sym.name = key;
+                        }
                         sym.name = EscapeHTML(key);
                         sym.description = EscapeHTML(sym.description);
 
@@ -117,9 +119,7 @@ function($, _, Humanize) {
             preprocess_item(item);
             Object.keys(item.symbols).map(function(key) {
                 var sym = item.symbols[key];
-                if (!sym.name) {
-                    sym.name = key;
-                }
+             
                 var str = '<strong>' + sym.name + '</strong>' + "(" + sym.score + ")";
 
                if (sym.options) {


### PR DESCRIPTION
The EscapeHTML function called with undefined value return "undefined" as string. This PR avoid giving undefined value to sym.name