### PR TITLE
DKIM header canonicalization: correctly handle more than two Received headers

### DIFF
--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -165,6 +165,7 @@ struct rspamd_dkim_sign_key_s {
 struct rspamd_dkim_header {
 	const gchar *name;
 	guint count;
+	guint count_total;
 };
 
 /* Parser of dkim params */
@@ -452,6 +453,7 @@ rspamd_dkim_parse_hdrlist_common (struct rspamd_dkim_common_ctx *ctx,
 					sizeof (struct rspamd_dkim_header));
 			new->name = h;
 			new->count = 0;
+			new->count_total = 1;
 
 			/* Check mandatory from */
 			if (!from_found && g_ascii_strcasecmp (h, "from") == 0) {
@@ -460,8 +462,10 @@ rspamd_dkim_parse_hdrlist_common (struct rspamd_dkim_common_ctx *ctx,
 
 			g_ptr_array_add (ctx->hlist, new);
 
-			if (g_hash_table_lookup (htb, h) != NULL) {
-				new->count++;
+			struct rspamd_dkim_header * old = g_hash_table_lookup (htb, h);
+			if (old != NULL) {
+				new->count += old->count_total;
+				old->count_total++;
 			}
 			else {
 				/* Insert new header to the list */


### PR DESCRIPTION
When rspamd verifies the DKIM signature of an email that had more than two _Received_ headers before the signature was applied, it always finds that the signature is invalid -- even though e.g. Perl's Mail::DKIM finds the signature valid.

Let's assume that we have N _Received_ headers in the signed part of the message. When looking into `rspamd_dkim_canonize_header_relaxed`, one can now see that that first the first _Received_ header is canonicalized, then the second one, and then the first one is canonicalized N-2 more times. This is because `rspamd_dkim_parse_hdrlist_common` appears to not have been designed to handle more than two instances of the same header.

This pull request keeps track of the total header count inside the `htb` hash table to fix the issue.