### PR TITLE
HTTP map: periodic callback after failed request

### DIFF
--- a/src/libutil/map.c
+++ b/src/libutil/map.c
@@ -755,6 +755,7 @@ read_data:
 	else {
 		msg_info_map ("cannot load map %s from %s: HTTP error %d",
 				bk->uri, cbd->data->host, msg->code);
+		rspamd_map_periodic_callback (-1, EV_TIMEOUT, cbd->periodic);
 	}
 
 	MAP_RELEASE (cbd, "http_callback_data");


### PR DESCRIPTION
If the webserver responds with e.g. a temporary error, like a 502, to an HTTP map request, one sees an error message like
```
2017-10-30 14:23:05 #8(controller) <9fydgy>; map; http_map_finish: cannot load map http://172.22.1.251:8081/settings.php from 172.22.1.251: HTTP error 502
```
and rspamd will not ever update the map again until it is manually restarted. This is because the branch that deals with status codes other than 200 and 304 does not set the periodic callback. This pull request adds that, though I have not yet been able to confirm whether this completely fixes the issue.