### PR TITLE
add check for spam flag from United Internet

### DIFF
--- a/rules/regexp/upstream_spam_filters.lua
+++ b/rules/regexp/upstream_spam_filters.lua
@@ -46,3 +46,10 @@ reconf['SPAM_FLAG'] = {
     description = "Message was already marked as spam",
     group = 'upstream_spam_filters'
 }
+
+reconf['UNITEDINTERNET_SPAM'] = {
+    re = 'X-UI-Out-Filterresults=/^junk:/H',
+    score = 5,
+    description = "United Internet says this message is spam",
+    group = 'upstream_spam_filters'
+}


### PR DESCRIPTION
This header is present for most outgoing messages from United Internet which
includes "web.de" and GMX (freemailers which are very popular in Germany) as
well as messages sent from 1and1 webhosting packages.