### PR TITLE
get authenticated user from client certificate subject

### DIFF
--- a/src/libserver/milter.c
+++ b/src/libserver/milter.c
@@ -1333,6 +1333,11 @@ rspamd_milter_macro_http (struct rspamd_milter_session *session,
 				found->begin, found->len);
 	}
 
+	IF_MACRO("{cert_subject}") {
+		rspamd_http_message_add_header_len (msg, USER_HEADER,
+				found->begin, found->len);
+	}
+
 	if (!session->hostname || session->hostname->len == 0) {
 		IF_MACRO("{client_name}") {
 			rspamd_http_message_add_header_len (msg, HOSTNAME_HEADER,


### PR DESCRIPTION
Hi,

in my postfix setup I have two different methods of authenticating users: sasl with passwords and client certificates.
rspamd only recognizes sasl authentication by evaluating the `{auth_authen}` macro. This tiny little PR also checks for `{cert_subject}`.

I've tested it against rspamd 1.6.5, works fine for me.
Any thoughts?

Kind regards

Phil