### PR TITLE
[Fix] Use the right boolean operator on error check

### DIFF
--- a/src/log_helper.c
+++ b/src/log_helper.c
@@ -153,7 +153,7 @@ rspamd_log_helper_read (gint fd, short what, gpointer ud)
 		}
 	}
 	else if (r == -1) {
-		if (errno != EAGAIN || errno != EINTR) {
+		if (errno != EAGAIN && errno != EINTR) {
 			msg_warn ("cannot read data from log pipe: %s", strerror (errno));
 			event_del (&ctx->log_ev);
 		}


### PR DESCRIPTION
It seems that someone used the wrong boolean operator here. The current condition means `if (True)`, while the new version makes perfect sense.

Thanks for your time,
Mike