### PR TITLE
[Fix] Deal with URLs wrapped in [] in text parts

### DIFF
--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -525,6 +525,7 @@ is_url_start (gchar c)
 {
 	if (c == '(' ||
 			c == '{' ||
+			c == '[' ||
 			c == '<' ||
 			c == '\'') {
 		return TRUE;
@@ -538,6 +539,7 @@ is_url_end (gchar c)
 {
 	if (c == ')' ||
 			c == '}' ||
+			c == ']' ||
 			c == '>' ||
 			c == '\'') {
 		return TRUE;


### PR DESCRIPTION
[sample message](https://aluminium.tinfoilcat.org/ww-ex.exml) - some extracted URLs have trailing %5D - this patch fixes that.