### PR TITLE
f-prot: match virus name non-greedily

### DIFF
--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -410,7 +410,7 @@ local function fprot_check(task, rule)
             rspamd_logger.infox(task, '%s [%s]: message is clean', rule['symbol'], rule['type'])
           end
         else
-          local vname = string.match(data, '^1 <infected: (.+)>')
+          local vname = string.match(data, '^1 <infected: (.+?)>')
           if not vname then
             rspamd_logger.errx(task, 'Unhandled response: %s', data)
           else


### PR DESCRIPTION
Recently I installed an f-prot-daemon to my mailserver and tested with an eicar attachment.
The f-prot-daemon's result line was
```
1 <infected: EICAR_Test_File> 1FFCE262AA->eicar.com
```
thus, rspamd's reject message was
```
554 5.7.1 fprot: virus found: \"EICAR_Test_File> 1FFCE262AA-\"
```
I checked with `fpscan --virlist | grep '>'` and there's no virus name containing a *greater than*, so a non-greedy match should be used here.