### PR TITLE
[Fix] Virus infection string for F-PROT Antivirus

### DIFF
--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -410,7 +410,9 @@ local function fprot_check(task, rule)
             rspamd_logger.infox(task, '%s [%s]: message is clean', rule['symbol'], rule['type'])
           end
         else
-          local vname = string.match(data, '^1 <.*infected.*: (.-)>')
+          -- returncodes: 1: infected, 2: suspicious, 3: both, 4-255: some error occured
+          -- see http://www.f-prot.com/support/helpfiles/unix/appendix_c.html for more detail
+          local vname = string.match(data, '^[1-3] <[%w%s]-: (.-)>')
           if not vname then
             rspamd_logger.errx(task, 'Unhandled response: %s', data)
           else

--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -410,7 +410,7 @@ local function fprot_check(task, rule)
             rspamd_logger.infox(task, '%s [%s]: message is clean', rule['symbol'], rule['type'])
           end
         else
-          local vname = string.match(data, '^1 <infected: (.-)>')
+          local vname = string.match(data, '^1 <contains?%s?infected%s?objects?: (.-)>')
           if not vname then
             rspamd_logger.errx(task, 'Unhandled response: %s', data)
           else

--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -410,7 +410,7 @@ local function fprot_check(task, rule)
             rspamd_logger.infox(task, '%s [%s]: message is clean', rule['symbol'], rule['type'])
           end
         else
-          local vname = string.match(data, '^1 <contains?%s?infected%s?objects?: (.-)>')
+          local vname = string.match(data, '^1 <.*infected.*: (.-)>')
           if not vname then
             rspamd_logger.errx(task, 'Unhandled response: %s', data)
           else


### PR DESCRIPTION
Fixes the error `(rspamd_proxy) ; lua; antivirus.lua:396: Unhandled response: 1 <contains infected objects: VIRUSNAME>` and therefore no handled detection

--
F-PROT Antivirus response if an infected file was found is
`1 <contains infected objects: VIRUSNAME>` for me, while rspamd only checks for `1 <infected: ...>`.

Unfortunately lua patterns don't allow optional unmatched groups and I don't know if the string differs in older installations or older/other setups which is why I tried to mark contains and objects as optional strings (and infected surrounded by optional whitespace).

System this was tried on: CentOS 7.2; rspamd 1.6.5 and F-PROT Antivirus fpscand version 6.0.3 (latest version from 2012/2013 with the latest signatures from 2018).