### PR TITLE
Fix endian and flock support on (some) SunOS platforms

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -155,6 +155,13 @@
  #include <sys/endian.h>
 #elif defined(HAVE_MACHINE_ENDIAN_H)
  #include <machine/endian.h>
+#elif defined(__sun)
+ #include <sys/byteorder.h>
+ #ifdef _LITTLE_ENDIAN
+  #define BYTE_ORDER LITTLE_ENDIAN
+ #else
+  #define BYTE_ORDER BIG_ENDIAN
+ #endif
 #endif
 
 #ifndef BYTE_ORDER

--- a/src/lua/lua_util.c
+++ b/src/lua/lua_util.c
@@ -1614,6 +1614,15 @@ lua_util_lock_file (lua_State *L)
 	gint fd = -1;
 	gboolean own = FALSE;
 
+#if !HAVE_FLOCK
+	struct flock fl = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_SET,
+		.l_start = 0,
+		.l_len = 0
+	};
+#endif
+
 	fpath = luaL_checkstring (L, 1);
 
 	if (fpath) {
@@ -1632,7 +1641,11 @@ lua_util_lock_file (lua_State *L)
 			return 2;
 		}
 
+#if HAVE_FLOCK
 		if (flock (fd, LOCK_EX) == -1) {
+#else
+		if (fcntl (fd, F_SETLKW, &fl) == -1) {
+#endif
 			lua_pushnil (L);
 			lua_pushstring (L, strerror (errno));
 
@@ -1658,6 +1671,15 @@ lua_util_unlock_file (lua_State *L)
 	gint fd = -1, ret, serrno;
 	gboolean do_close = TRUE;
 
+#if !HAVE_FLOCK
+	struct flock fl = {
+		.l_type = F_UNLCK,
+		.l_whence = SEEK_SET,
+		.l_start = 0,
+		.l_len = 0
+	};
+#endif
+
 	if (lua_isnumber (L, 1)) {
 		fd = lua_tonumber (L, 1);
 
@@ -1665,7 +1687,11 @@ lua_util_unlock_file (lua_State *L)
 			do_close = lua_toboolean (L, 2);
 		}
 
+#if HAVE_FLOCK
 		ret = flock (fd, LOCK_UN);
+#else
+		ret = fcntl (fd, F_SETLKW, &fl);
+#endif
 
 		if (do_close) {
 			serrno = errno;


### PR DESCRIPTION
While most recent Illumos platforms may have both endian.h and flock support (e.g. SmartOS in joyent_20171212T175708Z), more traditional ones do not (e.g. SmartOS in joyent_20141030T081701Z). These two commits allow rspamd to build there (similar fcntl workaround already exists in src/libutil/util.c).