### PR TITLE
[Feature] Support sending given header multiple times in lua_http

### DIFF
--- a/src/lua/lua_http.c
+++ b/src/lua/lua_http.c
@@ -316,16 +316,28 @@ static void
 lua_http_push_headers (lua_State *L, struct rspamd_http_message *msg)
 {
 	const char *name, *value;
+	gint i, sz;
 
 	lua_pushnil (L);
 	while (lua_next (L, -2) != 0) {
 
 		lua_pushvalue (L, -2);
 		name = lua_tostring (L, -1);
-		value = lua_tostring (L, -2);
-
-		if (name != NULL && value != NULL) {
-			rspamd_http_message_add_header (msg, name, value);
+		sz = rspamd_lua_table_size (L, -2);
+		if (sz != 0 && name != NULL) {
+			for (i = 1; i <= sz ; i++) {
+				lua_rawgeti (L, -2, i);
+				value = lua_tostring (L, -1);
+				if (value != NULL) {
+					rspamd_http_message_add_header (msg, name, value);
+				}
+				lua_pop (L, 1);
+			}
+		} else {
+			value = lua_tostring (L, -2);
+			if (name != NULL && value != NULL) {
+				rspamd_http_message_add_header (msg, name, value);
+			}
 		}
 		lua_pop (L, 2);
 	}


### PR DESCRIPTION
I discovered I have reason to send a given HTTP header multiple times in lua_http. This seems to work.

~~~lua
local rspamd_http = require 'rspamd_http'
rspamd_config.POINTLESS_HTTP = {
  callback = function (task)
    local function http_callback(err_message, code, body, headers)
      return
    end
    rspamd_http.request({
      task=task,
      url='http://127.0.0.1:56789/hello',
      body='hi',
      callback=http_callback,
      headers={
        One='10',
        Two='66',
        Multiple={'AHOY','HI','HELLO'},
      },
    })
  end
}
~~~