### PR TITLE
Add contrib/DEPENDENCY_INFO.md

### DIFF
--- a/contrib/DEPENDENCY_INFO.md
+++ b/contrib/DEPENDENCY_INFO.md
@@ -1,0 +1,24 @@
+# Rspamd Dependency Info
+
+- aho-corasick      Version: ?      License: LGPL-3.0               Patched: ?
+- cdb               Version: 1.1.0  License: Public Domain / CC0    Patched: ?
+- hiredis           Version: 0.13.3 License: BSD-3-Clause           Patched: ?
+- lc-btrie          Version: ?      License: BSD-3-Clause           Patched: ?
+- lgpl              Version: ?      License: LGPL-2.1               Patched: ?
+- libottery         Version: ?      License: Public Domain / CC0    Patched: ?
+- librdns           Version: ?      License: BSD-2-Clause           Patched: ?
+- libucl            Version: ?      License: BSD-2-Clause           Patched: ?
+- linenoise         Version: 1.0    License: BSD-2-Clause           Patched: ?
+- lpeg:             Version: 1.0    License: MIT                    Patched: ?
+- lua-fun           Version: ?      License: MIT                    Patched: ?
+- moses             Version: ?      License: MIT                    Patched: ?
+- mumhash           Version: ?      License: MIT                    Patched: ?
+- ngx-http-parser   Version: 2.2.0  License: MIT                    Patched: ?
+- perl-Mozilla-PublicSuffix
+                    Version: ?      License: MIT                    Patched: ?
+- snowball          Version: ?      License: BSD-3-Clause           Patched: ?
+- t1ha              Version: ?      License: Zlib                   Patched: ?
+- torch             Version: ?      License: ASL-2.0 v BSD-3-Clause Patched: ?
+- uthash            Version: 1.9.8  License: BSD                    Patched: ?
+- xxhash            Version: ?      License: BSD                    Patched: ?
+- zstd              Version: 1.3.1  License: BSD                    Patched: ?


### PR DESCRIPTION
I've made this list to make it easier to trace bundled libraries, their versions and their licenses.

However, it is not complete, yet.

If you have any of the missing information, like versions of bundled libs, or a short description of patches applied to them in this repo (or a short Patched: _yes_/_no_), that would be very much appreciated.

Thank you!

Edit: The list also does not yet cover JS dependencies, which should/could be included as well.