### PR TITLE
corrected headings in interface readme

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -1,6 +1,6 @@
-#Rspamd web interface
+# Rspamd web interface
 
-##Overview.
+## Overview.
 
 This is a simple control interface for rspamd spam filtering system.
 It provides basic functions for setting metric actions, scores,
@@ -8,7 +8,7 @@ viewing statistic and learning.
 
 <img src="https://rspamd.com/img/webui.png" class="img-responsive" alt="Webui screenshot">
 
-##Rspamd setup.
+## Rspamd setup.
 
 It is required to configure dynamic settings to store configured values.
 Basically this can be done by providing the following line in options settings:
@@ -39,12 +39,12 @@ worker {
 
 Password option should be changed for sure for your specific configuration. Encrypted password using is encouraged (`rspamadm pw --encrypt`).
 
-##Interface setup.
+## Interface setup.
 
 Interface itself is written in pure HTML5/js and, hence, it requires zero setup.
 Just enter a password for webui access and you are ready.
 
-##Contact information.
+## Contact information.
 
 Rspamd interface is distributed under the terms of [MIT license](http://opensource.org/licenses/MIT). For all questions related to this
 product please see the [support page](https://rspamd.com/support.html)


### PR DESCRIPTION
Corrected headings by implementing proper markdown in `interface/readme.md`