### PR TITLE
Allow the multimap header type to be a list of headers as well as a single header

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -708,8 +708,15 @@ local function multimap_callback(task, rule)
       end
     end,
     header = function()
-      local hv = task:get_header_full(rule['header'])
-      match_list(rule, hv, {'decoded'})
+      if type(rule['header']) == 'table' then
+        for _,rh in ipairs(rule['header']) do
+          local hv = task:get_header_full(rh)
+          match_list(rule, hv, {'decoded'})
+        end
+      else
+        local hv = task:get_header_full(rule['header'])
+        match_list(rule, hv, {'decoded'})
+      end
     end,
     rcpt = function()
       if task:has_recipients('smtp') then


### PR DESCRIPTION
I'm writing a multimap set that relies on different headers with similar values set by different MTAs. This would allow you, for example, to merge the freemail_envfrom and freemail_envrcpt multimaps to use one symbol if you wished, or to check both To and Cc headers for an address without writing two maps.

You may already have nixed this idea for good reasons! If not, I have found it a useful option.