### PR TITLE
Subject privacy for webUI

### DIFF
--- a/conf/modules.d/history_redis.conf
+++ b/conf/modules.d/history_redis.conf
@@ -18,6 +18,8 @@ history_redis {
   key_prefix = "rs_history"; # Default key name
   nrows = 200; # Default rows limit
   compress = true; # Use zstd compression when storing data in redis
+  subject_privacy = false; # subject privacy is off
+  subject_privacy_alg = 'md5'; # default hash-algorithm to obfuscate subject
 
   .include(try=true,priority=5) "${DBDIR}/dynamic/history_redis.conf"
   .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/history_redis.conf"

--- a/conf/modules.d/history_redis.conf
+++ b/conf/modules.d/history_redis.conf
@@ -19,7 +19,6 @@ history_redis {
   nrows = 200; # Default rows limit
   compress = true; # Use zstd compression when storing data in redis
   subject_privacy = false; # subject privacy is off
-  subject_privacy_alg = 'md5'; # default hash-algorithm to obfuscate subject
 
   .include(try=true,priority=5) "${DBDIR}/dynamic/history_redis.conf"
   .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/history_redis.conf"

--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -26,7 +26,9 @@ local settings = {
   nrows = 200, -- default rows limit
   compress = true, -- use zstd compression when storing data in redis
   subject_privacy = false, -- subject privacy is off
-  subject_privacy_alg = 'md5', -- default hash-algorithm to obfuscate subject
+  subject_privacy_alg = 'blake2', -- default hash-algorithm to obfuscate subject
+  subject_privacy_prefix = 'obf', -- prefix to show it's obfuscated
+  subject_privacy_length = 16, -- cut the length of the hash
 }
 
 local rspamd_logger = require "rspamd_logger"
@@ -201,7 +203,7 @@ local function handle_history_request(task, conn, from, to, reset)
           elseif settings.subject_privacy then
             local hash_alg = settings.subject_privacy_alg
             local subject_hash = hash.create_specific(hash_alg, e.subject)
-            e.subject = hash_alg..':'..subject_hash:hex()
+            e.subject = settings.subject_privacy_prefix .. ':' .. subject_hash:hex():sub(1,settings.subject_privacy_length)
           end
         end, data)
         reply.rows = data


### PR DESCRIPTION
I added an option for "Subject privacy" in the webUI, as the subject may include personal information, which I don't want to see. This is only relevant when redis is used as storage for the history.

It just hashes the subject, so you can still see that a lot of spam-mails have the same subject.
I chose md5 as default, because it results in a shorter string.

