### PR TITLE
Improve readability of AR-header

### DIFF
--- a/lualib/lua_auth_results.lua
+++ b/lualib/lua_auth_results.lua
@@ -191,8 +191,10 @@ local function gen_auth_results(task, settings)
     table.insert(hdr_parts, hdr)
   end
 
+  local fold_symbol = task:has_flag("milter") and "\n" or "\r\n"
+
   if #hdr_parts > 0 then
-    return table.concat(hdr_parts, '; ')
+    return table.concat(hdr_parts, ';' .. fold_symbol)
   end
 
   return nil


### PR DESCRIPTION
Concat `hdr_parts` with a newline instead of a space, similar to OpenDKIM and the implementation of many big mail providers (i.e. gmail).