### PR TITLE
Web UI - Add specific numbers to stats values

### DIFF
--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -74,7 +74,8 @@ function($, d3pie, Humanize) {
                     '</strong>' + i + '</div>';
                 $(widget).appendTo(widgets);
             } else {
-                widget = '<li class="stat-box"><div class="widget"><strong>' +
+                var titleAtt = Humanize.intComma(item) + ' ' + i;
+                widget = '<li class="stat-box"><div class="widget" title="' + titleAtt + '"><strong>' +
                     Humanize.compactInteger(item) + '</strong>' + i + '</div></li>';
                 if (i == 'scanned') {
                     stat_w[0] = widget;


### PR DESCRIPTION
Use a `title` attribute on the stats widgets to show full specific values in addition to the `Humanize.compactInteger()` values when hovering over the compact values.