### PR TITLE
Add optional status prefix to X-Virus header

### DIFF
--- a/src/plugins/lua/milter_headers.lua
+++ b/src/plugins/lua/milter_headers.lua
@@ -71,6 +71,8 @@ local settings = {
     ['x-virus'] = {
       header = 'X-Virus',
       remove = 1,
+      status_clean = nil,
+      status_infected = nil,
       symbols = {}, -- needs config
     },
     ['x-spamd-bar'] = {
@@ -344,7 +346,13 @@ local function milter_headers(task)
       end
     end
     if #virii > 0 then
-      add_header('x-virus', table.concat(virii, ','))
+      local virusstatus = table.concat(virii, ',')
+      if settings.routines['x-virus'].status_infected then
+        virusstatus = settings.routines['x-virus'].status_infected .. ', ' .. virusstatus
+      end
+      add_header('x-virus', virusstatus)
+    elseif settings.routines['x-virus'].status_clean then
+      add_header('x-virus', settings.routines['x-virus'].status_clean)
     end
   end
 


### PR DESCRIPTION
When trying to configure the virustest extension of dovecot's sieve implementation (pidgeonhole), the x-virus milter header routine turned out to be incompatible with the limited configuration possibilities of the sieve plugin. In its simplest form, it requires a fixed header value (prefix) that can be matched against. 

This change adds two options to the X-Virus milter header routine that prefix the header value with a configured string when a virus was found (or not).

An alternative solution adding a new header routine has been implemented in #2206

I personally prefer this solution, since it requires less code changes and does not require duplicate configuration (of virus symbols).

Given the following configuration:

```groovy
use = ['x-virus'];
routines {
  x-virus {
    status_clean = 'Clean';
    status_infected = 'Infected';
    symbols = [ 'CLAM_VIRUS', 'JUST_EICAR' ];
  }
}
```
the routine would produce the following headers:

- for an EICAR message: `X-Virus: Infected, Eicar-Test-Signature`
- for a clean message: `X-Virus: Clean`

I understand that a "Clean" header might be problematic, since it would also be applied when the virus scanner could not be reached, for example. Unfortunately, the antivirus plugin does not seem to provide access to this information. The value is configurabe and its usage disabled by default, so this requires an explicit decision by the administrator, which seems acceptable.

