### PR TITLE
Small libucl fixes

### DIFF
--- a/contrib/libucl/lua_ucl.c
+++ b/contrib/libucl/lua_ucl.c
@@ -550,10 +550,10 @@ ucl_object_lua_import_escape (lua_State *L, int idx)
 	t = lua_type (L, idx);
 	switch (t) {
 	case LUA_TTABLE:
-		obj = ucl_object_lua_fromtable (L, idx, UCL_STRING_ESCAPE);
+		obj = ucl_object_lua_fromtable (L, idx, UCL_STRING_RAW);
 		break;
 	default:
-		obj = ucl_object_lua_fromelt (L, idx, UCL_STRING_ESCAPE);
+		obj = ucl_object_lua_fromelt (L, idx, UCL_STRING_RAW);
 		break;
 	}
 

--- a/contrib/libucl/ucl_emitter_utils.c
+++ b/contrib/libucl/ucl_emitter_utils.c
@@ -125,7 +125,7 @@ ucl_elt_string_write_json (const char *str, size_t size,
 				func->ucl_emitter_append_len ("\\f", 2, func->ud);
 				break;
 			case '\v':
-				func->ucl_emitter_append_len ("\\v", 2, func->ud);
+				func->ucl_emitter_append_len ("\\u000B", 6, func->ud);
 				break;
 			case '\\':
 				func->ucl_emitter_append_len ("\\\\", 2, func->ud);


### PR DESCRIPTION
626c7a1 attempted to fix vertical tab handling, but '\v' is not a valid JSON escape so most parsers will reject it.

libucl has two places that escape strings, 626c7a1 didn't modify the one that occurs during parsing, so I have done so.

As far as I can tell there's no reason for lua_ucl to use UCL_STRING_ESCAPE; strings are escaped again during JSON/UCL generation, producing excessively escaped output. Example:
```
"description": "To header display name is \\\"Recipients\\\""
```