### PR TITLE
add more Spamhaus RBL results to received IPs

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -43,8 +43,12 @@ rbl {
             from = false;
             ignore_whitelists = true;
             returncodes {
+                RECEIVED_SPAMHAUS_SBL = "127.0.0.2";
+                RECEIVED_SPAMHAUS_CSS = "127.0.0.3";
                 RECEIVED_SPAMHAUS_XBL = ["127.0.0.4", "127.0.0.5",
                     "127.0.0.6", "127.0.0.7"];
+                RECEIVED_SPAMHAUS_PBL = ["127.0.0.10", "127.0.0.11"];
+                RECEIVED_SPAMHAUS_DROP = "127.0.0.9";
             }
         }
 

--- a/conf/scores.d/rbl_group.conf
+++ b/conf/scores.d/rbl_group.conf
@@ -69,9 +69,29 @@ symbols = {
         weight = 7.0;
         description = "From address is listed in zen drop bl";
     }
+    "RECEIVED_SPAMHAUS_SBL" {
+        weight = 1.0;
+        description = "Received address is listed in zen sbl";
+        one_shot = true;
+    }
+    "RECEIVED_SPAMHAUS_CSS" {
+        weight = 1.0;
+        description = "Received address is listed in zen css";
+        one_shot = true;
+    }
     "RECEIVED_SPAMHAUS_XBL" {
         weight = 3.0;
         description = "Received address is listed in zen xbl";
+        one_shot = true;
+    }
+    "RECEIVED_SPAMHAUS_PBL" {
+        weight = 0.0;
+        description = "Received address is listed in pbl (ISP list)";
+        one_shot = true;
+    }
+    "RECEIVED_SPAMHAUS_DROP" {
+        weight = 6.0;
+        description = "Received address is listed in zen drop bl";
         one_shot = true;
     }
 


### PR DESCRIPTION
Also add Spamhaus RBL checks for SBL, PBL and so on to the "Received IPs".

Example: An email sent from an IP listed at SBL might be more propable spam.