### PR TITLE
Ratelimit - fix set symbol only

### DIFF
--- a/conf/modules.d/ratelimit.conf
+++ b/conf/modules.d/ratelimit.conf
@@ -30,6 +30,10 @@ ratelimit {
     #}
     # If symbol is specified, then it is inserted instead of setting result
     #symbol = "R_RATELIMIT";
+
+    # If info_symbol is specified, then it is inserted next to set the result
+    #info_symbol = "R_RATELIMIT_INFO";
+
     whitelisted_rcpts = "postmaster,mailer-daemon";
     max_rcpt = 5;
 

--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -377,7 +377,15 @@ local function ratelimit_cb(task)
       if err then
         rspamd_logger.errx('cannot check limit %s: %s %s', prefix, err, data)
       elseif type(data) == 'table' and data[1] and data[1] == 1 then
-        if settings.info_symbol then
+        -- set symbol only and do NOT soft reject
+        if settings.symbol then
+          task:insert_result(settings.symbol, 0.0, prefix)
+          rspamd_logger.infox(task,
+                  'set_symbol_only: ratelimit "%s(%s)" exceeded, (%s / %s): %s (%s:%s dyn)',
+                  lim_name, prefix, bucket[2], bucket[1], data[2], data[3], data[4])
+          return
+        -- set INFO symbol and soft reject
+        elseif settings.info_symbol then
           task:insert_result(settings.info_symbol, 1.0, prefix)
         end
         rspamd_logger.infox(task,

--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -379,14 +379,14 @@ local function ratelimit_cb(task)
       elseif type(data) == 'table' and data[1] and data[1] == 1 then
         -- set symbol only and do NOT soft reject
         if settings.symbol then
-          task:insert_result(settings.symbol, 0.0, prefix)
+          task:insert_result(settings.symbol, 0.0, lim_name .. "(" .. prefix .. ")")
           rspamd_logger.infox(task,
                   'set_symbol_only: ratelimit "%s(%s)" exceeded, (%s / %s): %s (%s:%s dyn)',
                   lim_name, prefix, bucket[2], bucket[1], data[2], data[3], data[4])
           return
         -- set INFO symbol and soft reject
         elseif settings.info_symbol then
-          task:insert_result(settings.info_symbol, 1.0, prefix)
+          task:insert_result(settings.info_symbol, 1.0, lim_name .. "(" .. prefix .. ")") 
         end
         rspamd_logger.infox(task,
                 'ratelimit "%s(%s)" exceeded, (%s / %s): %s (%s:%s dyn)',


### PR DESCRIPTION
    # If symbol is specified, then it is inserted instead of setting result
    #symbol = "R_RATELIMIT";

Setting the symbol was not considered in the Plugin Code.

