### PR TITLE
Don't mark "neutral" symbol weights as negative in the web ui

### DIFF
--- a/interface/js/app/symbols.js
+++ b/interface/js/app/symbols.js
@@ -97,7 +97,7 @@ function($) {
                 var label_class = '';
                 if (item.weight < 0) {
                     label_class = 'scorebar-ham';
-                } else {
+                } else if (item.weight > 0) {
                     label_class = 'scorebar-spam';
                 }
                 item.weight = '<input class="form-control input-sm mb-disabled ' + label_class +


### PR DESCRIPTION
It is a bit misleading to mark "neutral" symbols (with a weight of exactly zero) with a red css background.

In my optinion, just remove the css class if that's the case.