### PR TITLE
add rule for rogue "strongmail" MTA

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -589,8 +589,16 @@ reconf['YANDEX_RU_MAILER'] = {
 -- Detect 1C v8.2 and v8.3 mailers
 reconf['MAILER_1C_8'] = {
     re = 'X-Mailer=/^1C:Enterprise 8\\.[23]$/H',
-    score = 0,
+    score = 0.0,
     description = 'Sent with 1C:Enterprise 8',
+    group = 'header'
+}
+
+-- Detect rogue 'strongmail' MTA with IPv4 and '(-)' in Received line
+reconf['STRONGMAIL'] = {
+    re = [[Received=/^from\s+strongmail\s+\(\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\]\) by \S+ \(-\); /mH]],
+    score = 6.0,
+    description = 'Sent via rogue "strongmail" MTA',
     group = 'header'
 }
 


### PR DESCRIPTION
Some health insurance and payback spam is sent via a rogue MTA called "strongmail". Since it is relayed via Gmail (mostly), greylisting won't help.

Added a rule to catch this and add some extra points on it.