### PR TITLE
add scores to DNSWL entries

### DIFF
--- a/conf/scores.d/rbl_group.conf
+++ b/conf/scores.d/rbl_group.conf
@@ -29,15 +29,15 @@ symbols = {
         description = "Sender listed at https://www.dnswl.org, no trust";
     }
     "RCVD_IN_DNSWL_LOW" {
-        weight = 0.0;
+        weight = -0.5;
         description = "Sender listed at https://www.dnswl.org, low trust";
     }
     "RCVD_IN_DNSWL_MED" {
-        weight = 0.0;
+        weight = -2.0;
         description = "Sender listed at https://www.dnswl.org, medium trust";
     }
     "RCVD_IN_DNSWL_HI" {
-        weight = 0.0;
+        weight = -4.0;
         description = "Sender listed at https://www.dnswl.org, high trust";
     }
 


### PR DESCRIPTION
Honour DNSWL listings (low: -0.5 points, medium: -2.0, high: -4.0) in order to minimize false positives.
Since DNSWL provides a reporting function for abuse and rates conservatively, this should not be a problem spam-wise.