### PR TITLE
fix email address parsing: ebraces should increase till equals obraces

### DIFF
--- a/src/libmime/email_addr.c
+++ b/src/libmime/email_addr.c
@@ -372,7 +372,7 @@ rspamd_email_address_from_mime (rspamd_mempool_t *pool,
 				obraces ++;
 			}
 			else if (*p == ')') {
-				ebraces --;
+				ebraces ++;
 			}
 
 			if (obraces == ebraces) {


### PR DESCRIPTION
Without this patch an address like `Name (comment ) <email>` won't be parsed correctly. E.g. postfix bounce messages.