### PR TITLE
Add mos.ru to whitelists

### DIFF
--- a/conf/dmarc_whitelist.inc
+++ b/conf/dmarc_whitelist.inc
@@ -40,6 +40,7 @@ megafon.ru
 mercadolibre.com.ar
 mercadolivre.com.br
 messenger.com
+mos.ru
 mvideo.ru
 neobux.com
 netflix.com

--- a/conf/spf_dkim_whitelist.inc
+++ b/conf/spf_dkim_whitelist.inc
@@ -130,6 +130,7 @@ messenger.com
 microsoft.com
 microsoftonline.com
 moikrug.ru
+mos.ru
 mts.ru
 neobux.com
 netflix.com


### PR DESCRIPTION
Mos.ru is more or less popular website in Moscow region of Russia. They send notifications about housing and utilities payments, and related information.

They send emails with various problems (wrong msg ID, URLs from RBL, etc), but with valid DKIM and matching SPF. They also have 'reject' policy enable for DMARC.

I believe, it's worth adding mos.ru into whitelists to improve delivery of their letters