### PR TITLE
Add generic service feed to phishing module

### DIFF
--- a/src/plugins/lua/phishing.lua
+++ b/src/plugins/lua/phishing.lua
@@ -400,7 +400,7 @@ local function phishtank_json_cb(string)
 
   if not res then
     valid = false
-    rspamd_logger.warnx(phishtank_hash, 'cannot parse openphish map: ' .. err)
+    rspamd_logger.warnx(phishtank_hash, 'cannot parse phishtank map: ' .. err)
   else
     local obj = parser:get_object()
 


### PR DESCRIPTION
Hi there,

We have a Phishing URL validate service called CaUMa developed to represent local phishing frauds in Brazil, that service is maintained by 'Cert.Bahia'[1] and RNP[2].

We create a "generic service" in phishing module to integrate CaUMa feed without disabling any of the supported services by phishing module (PhishTank and Openphish). That allows someone to use a custom feed without remove already supported feeds.

We are using it now and is working fine! If this merge is cool to the project, We will be glad to update the documentation in 'rspamd.com' repository and fixing any issue in that patch.

[1] https://certbahia.pop-ba.rnp.br
[2] https://www.rnp.br/en
[3] https://cauma.pop-ba.rnp.br

Best Regard.